### PR TITLE
Workaround for Diffuse Baking

### DIFF
--- a/bakelab_bake.py
+++ b/bakelab_bake.py
@@ -535,6 +535,8 @@ class Baker(Operator):
                 if map.type == 'CustomPass':
                     if map.deep_search:
                         self.ungroup_nodes(mat.node_tree)
+                    if "Base Color" in map.pass_name:
+                        mat.metallic = 0
                     self.passes_to_emit_node(mat, map.pass_name)
                 if map.type == 'Albedo':
                     self.ungroup_nodes(mat.node_tree)


### PR DESCRIPTION
The Principled BSDF shader doesn't bake the Diffuse (Base Color) properly when the metallic is not zero. This workaround is for using a Custom Pass with the property set to Base Color. Did some testing and is working for me when baking out PBR work flow:

Base Color (custom pass with this workaround)
Metallic (custom pass)
Roughness
Normal